### PR TITLE
Return an error if there are two enums with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@
   enhancing type safety and compatibility.
   [#3647](https://github.com/rustwasm/wasm-bindgen/pull/3647)
 
+* Stop tolerating name collisions on enums, this would previously just emit one of them.
+  [#3669](https://github.com/rustwasm/wasm-bindgen/pull/3669)
+
 ### Fixed
 
 * Fixed `wasm_bindgen` macro to handle raw identifiers in field names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
   enhancing type safety and compatibility.
   [#3647](https://github.com/rustwasm/wasm-bindgen/pull/3647)
 
-* Stop tolerating name collisions on enums, this would previously just emit one of them.
+* Throw an error on enum name collisions, previously only one enum would be emitted.
   [#3669](https://github.com/rustwasm/wasm-bindgen/pull/3669)
 
 ### Fixed

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2455,7 +2455,7 @@ impl<'a> Context<'a> {
         pairs.sort_by_key(|(k, _)| *k);
         check_duplicated_getter_and_setter_names(&pairs)?;
 
-        for e in self.aux.enums.iter() {
+        for (_, e) in self.aux.enums.iter() {
             self.generate_enum(e)?;
         }
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -852,8 +852,15 @@ impl<'a> Context<'a> {
                 .collect(),
             generate_typescript: enum_.generate_typescript,
         };
-        self.aux.enums.push(aux);
-        Ok(())
+        let mut result = Ok(());
+        self.aux
+            .enums
+            .entry(aux.name.clone())
+            .and_modify(|existing| {
+                result = Err(anyhow!("duplicate enums:\n{:?}\n{:?}", existing, aux));
+            })
+            .or_insert(aux);
+        result
     }
 
     fn struct_(&mut self, struct_: decode::Struct<'_>) -> Result<(), Error> {

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -41,7 +41,7 @@ pub struct WasmBindgenAux {
 
     /// Auxiliary information to go into JS/TypeScript bindings describing the
     /// exported enums from Rust.
-    pub enums: Vec<AuxEnum>,
+    pub enums: HashMap<String, AuxEnum>,
 
     /// Auxiliary information to go into JS/TypeScript bindings describing the
     /// exported structs from Rust and their fields they've got exported.

--- a/tests/wasm/node.js
+++ b/tests/wasm/node.js
@@ -24,14 +24,14 @@ exports.test_works = function() {
   assert.strictEqual(r2.add(2), 13);
   r2.free();
 
-  assert.strictEqual(wasm.Color.Green, 0);
-  assert.strictEqual(wasm.Color.Yellow, 1);
-  assert.strictEqual(wasm.Color.Red, 2);
-  assert.strictEqual(wasm.Color[0], 'Green');
-  assert.strictEqual(wasm.Color[1], 'Yellow');
-  assert.strictEqual(wasm.Color[2], 'Red');
-  assert.strictEqual(Object.keys(wasm.Color).length, 6);
-  assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
+  assert.strictEqual(wasm.NodeColor.Green, 0);
+  assert.strictEqual(wasm.NodeColor.Yellow, 1);
+  assert.strictEqual(wasm.NodeColor.Red, 2);
+  assert.strictEqual(wasm.NodeColor[0], 'Green');
+  assert.strictEqual(wasm.NodeColor[1], 'Yellow');
+  assert.strictEqual(wasm.NodeColor[2], 'Red');
+  assert.strictEqual(Object.keys(wasm.NodeColor).length, 6);
+  assert.strictEqual(wasm.cycle(wasm.NodeColor.Green), wasm.NodeColor.Yellow);
 
   wasm.node_math(1.0, 2.0);
 };

--- a/tests/wasm/node.rs
+++ b/tests/wasm/node.rs
@@ -34,18 +34,19 @@ impl Foo {
     }
 }
 
+// Use a different name to avoid a collision with the `Color` enum in enums.rs when --no-modules is used.
 #[wasm_bindgen]
-pub enum Color {
+pub enum NodeColor {
     Green,
     Yellow,
     Red,
 }
 #[wasm_bindgen]
-pub fn cycle(color: Color) -> Color {
+pub fn cycle(color: NodeColor) -> NodeColor {
     match color {
-        Color::Green => Color::Yellow,
-        Color::Yellow => Color::Red,
-        Color::Red => Color::Green,
+        NodeColor::Green => NodeColor::Yellow,
+        NodeColor::Yellow => NodeColor::Red,
+        NodeColor::Red => NodeColor::Green,
     }
 }
 


### PR DESCRIPTION
This fixes the issue that two enums with the same name cause the "second" one to overwrite the "first" one.

Currently, looking at the output of `target/wasm32-unknown-unknown/wbg-tmp-wasm-<some-hex-characters>.wasm/wasm-bindgen-test.js` generated with 
```
WASM_BINDGEN_SPLIT_LINKED_MODULES=1 cargo test --target wasm32-unknown-unknown
```

the part with the enums (was at line 4849 for me) looks like this:

```js
**
*/
module.exports.Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
/**
*/
module.exports.JsRenamedEnum = Object.freeze({ A:10,"10":"A",B:20,"20":"B", });
/**
*/
module.exports.EnumArrayElement = Object.freeze({ Unit:0,"0":"Unit", });
/**
* annotated enum type
*/
module.exports.AnnotatedEnum = Object.freeze({
/**
* annotated enum variant 1
*/
Variant1:0,"0":"Variant1",
/**
* annotated enum variant 2
*/
Variant2:1,"1":"Variant2", });
/**
*/
module.exports.Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
/**
*/
module.exports.ColorWithCustomValues = Object.freeze({ Green:21,"21":"Green",Yellow:34,"34":"Yellow",Red:2,"2":"Red", });
/**
*/
module.exports.MyEnum = Object.freeze({ One:1,"1":"One",Two:2,"2":"Two", });
```

The second assignment `module.exports.Color =`  overwrites the first one, causing the first one to have no effect.

The reason this was not captured by the tests is that the two enums were identical in shape (same unit keys/values).